### PR TITLE
Fix installation issues for Ubuntu 16.04

### DIFF
--- a/gym_gazebo/envs/installation/gazebo.repos
+++ b/gym_gazebo/envs/installation/gazebo.repos
@@ -31,7 +31,7 @@ repositories:
   ecl_lite:
     type: git
     url: https://github.com/stonier/ecl_lite
-    version: devel
+    version: release/0.61-indigo-kinetic
   ecl_navigation:
     type: git
     url: https://github.com/stonier/ecl_navigation
@@ -39,7 +39,7 @@ repositories:
   ecl_tools:
     type: git
     url: https://github.com/stonier/ecl_tools
-    version: devel
+    version:  release/0.61-indigo-kinetic
   driver_base:
     type: git
     url: https://github.com/ros-drivers/driver_common.git

--- a/gym_gazebo/envs/installation/gazebo.repos
+++ b/gym_gazebo/envs/installation/gazebo.repos
@@ -14,7 +14,7 @@ repositories:
   ecl_core:
     type: git
     url: https://github.com/stonier/ecl_core
-    version: devel
+    version: release/0.61-indigo-kinetic
   ecl_lite:
     type: git
     url: https://github.com/stonier/ecl_lite
@@ -22,7 +22,7 @@ repositories:
   ecl_navigation:
     type: git
     url: https://github.com/stonier/ecl_navigation
-    version: devel
+    version: release/0.61-indigo-kinetic
   ecl_tools:
     type: git
     url: https://github.com/stonier/ecl_tools

--- a/gym_gazebo/envs/installation/gazebo.repos
+++ b/gym_gazebo/envs/installation/gazebo.repos
@@ -98,7 +98,7 @@ repositories:
   xacro:
     type: git
     url: https://github.com/ros/xacro
-    version: indigo-devel
+    version: kinetic-devel
   yocs_msgs:
     type: git
     url: https://github.com/yujinrobot/yocs_msgs

--- a/gym_gazebo/envs/installation/gazebo.repos
+++ b/gym_gazebo/envs/installation/gazebo.repos
@@ -8,10 +8,10 @@ repositories:
 #    type: git
 #    url: https://github.com/sniekum/ar_track_alvar
 #    version: indigo-devel
-#  ar_track_alvar_msgs:
-#    type: git
-#    url: https://github.com/sniekum/ar_track_alvar_msgs
-#    version: indigo-devel
+  ar_track_alvar_msgs:
+    type: git
+    url: https://github.com/sniekum/ar_track_alvar_msgs
+    version: indigo-devel
   catkin_simple:
     type: git
     url: https://github.com/catkin/catkin_simple.git

--- a/gym_gazebo/envs/installation/gazebo.repos
+++ b/gym_gazebo/envs/installation/gazebo.repos
@@ -1,13 +1,4 @@
 repositories:
-#  ardupilot_sitl_gazebo_plugin:
-#    type: git
-#    url: https://github.com/erlerobot/ardupilot_sitl_gazebo_plugin
-#
-#    version: master
-#  ar_track_alvar:
-#    type: git
-#    url: https://github.com/sniekum/ar_track_alvar
-#    version: indigo-devel
   ar_track_alvar_msgs:
     type: git
     url: https://github.com/sniekum/ar_track_alvar_msgs
@@ -20,10 +11,6 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
     version: indigo-devel
-#  drcsim:
-#    type: hg
-#    url: https://bitbucket.org/osrf/drcsim
-#    version: default
   ecl_core:
     type: git
     url: https://github.com/stonier/ecl_core
@@ -48,10 +35,6 @@ repositories:
     type: git
     url: https://github.com/ros-simulation/gazebo_ros_pkgs
     version: indigo-devel
-#  glog_catkin:
-#    type: git
-#    url: https://github.com/ethz-asl/glog_catkin.git
-#    version: master
   hector_gazebo:
     type: git
     url: https://github.com/tu-darmstadt-ros-pkg/hector_gazebo/
@@ -80,34 +63,14 @@ repositories:
     type: git
     url: https://github.com/yujinrobot/kobuki_msgs
     version: indigo
-#  mavros:
-#    type: git
-#    url: https://github.com/erlerobot/mavros.git
-#    version: gazebo_udp
-#  mav_comm:
-#    type: git
-#    url: https://github.com/PX4/mav_comm.git
-#    version: master
   navigation:
     type: git
     url: https://github.com/ros-planning/navigation
     version: indigo-devel
-#  osrf-common:
-#    type: hg
-#    url: https://bitbucket.org/osrf/osrf-common
-#    version: default
   pcl_ros:
     type: git
     url: https://github.com/ros-perception/perception_pcl.git
     version: indigo-devel
-#  python_qt_binding:
-#    type: git
-#    url: https://github.com/ros-visualization/python_qt_binding
-#    version: kinetic-devel
-#  qt_gui_core:
-#    type: git
-#    url: https://github.com/ros-visualization/qt_gui_core
-#    version: groovy-devel
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools
@@ -120,18 +83,6 @@ repositories:
     type: git
     url: https://github.com/ros/roslint
     version: master
-#  rqt:
-#    type: git
-#    url: https://github.com/ros-visualization/rqt
-#    version: groovy-devel
-#  rqt_common_plugins:
-#    type: git
-#    url: https://github.com/ros-visualization/rqt_common_plugins
-#    version: master
-#  rqt_robot_plugins:
-#    type: git
-#    url: https://github.com/ros-visualization/rqt_robot_plugins
-#    version: master
   turtlebot:
     type: git
     url: https://github.com/turtlebot/turtlebot

--- a/gym_gazebo/envs/installation/setup_kinetic.bash
+++ b/gym_gazebo/envs/installation/setup_kinetic.bash
@@ -22,54 +22,6 @@ mkdir -p $src
 cd $src
 catkin_init_workspace
 
-# # Install dependencies
-# sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
-# sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-key 0xB01FA116
-# sudo apt-get update
-# sudo apt-get install -y git                            \
-#                         mercurial                      \
-#                         libsdl-image1.2-dev            \
-#                         libspnav-dev                   \
-#                         libtbb-dev                     \
-#                         libtbb2                        \
-#                         libusb-dev libftdi-dev         \
-#                         pyqt4-dev-tools                \
-#                         python-vcstool                 \
-#                         ros-indigo-bfl                 \
-#                         python-pip                     \
-#                         g++                            \
-#                         ccache                         \
-#                         realpath                       \
-#                         libopencv-dev                  \
-#                         libtool                        \
-#                         automake                       \
-#                         autoconf                       \
-#                         libexpat1-dev                  \
-#                         ros-indigo-mavlink             \
-#                         ros-indigo-octomap-msgs        \
-#                         ros-indigo-joy                 \
-#                         ros-indigo-geodesy             \
-#                         ros-indigo-octomap-ros         \
-#                         ros-indigo-control-toolbox     \
-# 			ros-indigo-pluginlib	       \
-# 			ros-indigo-trajectory-msgs     \
-# 			ros-indigo-control-msgs	       \
-# 			ros-indigo-std-srvs 	       \
-# 			ros-indigo-nodelet	       \
-# 			ros-indigo-urdf		       \
-# 			ros-indigo-rviz		       \
-# 			ros-indigo-kdl-conversions     \
-# 			ros-indigo-eigen-conversions   \
-# 			ros-indigo-tf2-sensor-msgs     \
-# 			ros-indigo-pcl-ros	       \
-#                         gawk                           \
-#                         libtinyxml2-dev
-# sudo easy_install numpy
-# sudo easy_install --upgrade numpy
-# sudo pip install --upgrade matplotlib
-# sudo pip2 install pymavlink MAVProxy catkin_pkg --upgrade
-# echo "\nDependencies installed\n"
-
 
 # Import and build dependencies
 cd ../../catkin_ws/src/
@@ -94,15 +46,3 @@ if [ -z "$GAZEBO_MODEL_PATH" ]; then
   bash -c 'echo "export GAZEBO_MODEL_PATH="`pwd`/../../assets/models >> ~/.bashrc'
   exec bash #reload bashrc
 fi
-
-# # Theano and Keras installation and requisites
-# cd ../
-# sudo pip install h5py
-# sudo apt-get install gfortran
-# git clone git://github.com/Theano/Theano.git
-# cd Theano/
-# sudo python setup.py develop
-# sudo pip install keras
-#
-# echo "## Theano and Keras installed ##"
-# echo "## Installation finished ##"

--- a/gym_gazebo/envs/installation/setup_kinetic.bash
+++ b/gym_gazebo/envs/installation/setup_kinetic.bash
@@ -76,6 +76,13 @@ cd ../../catkin_ws/src/
 vcs import < ../../gazebo.repos
 
 cd ..
+
+#Create CATKIN_IGNORE files in kobuki_qtestsuite, wiimote and spacenav_node so we can compile
+
+touch src/kobuki_desktop/kobuki_qtestsuite/CATKIN_IGNORE
+touch src/joystick_drivers/wiimote/CATKIN_IGNORE
+touch src/joystick_drivers/spacenav_node/CATKIN_IGNORE
+
 catkin_make --pkg mav_msgs
 source devel/setup.bash
 catkin_make -j 1


### PR DESCRIPTION
# This pull request fixes several problems with the installation for Ubuntu 16.04. 
## The following has changed:
gazebo.repos:
- ecl-tools and ecl-light are now both pulled from the release/0.61-indigo-kinetic branch
- xacro will be pulled from the kinetic-devel branch
- since yocs_ar_pair_tracking needs ar_track_alvar_msgs this section was uncommented
- commented code is removed

setup_kinetic.bash:
- Since there are compile problems with spacenav_node wiimote and kobuki_qtestsuit the setup script automatically adds a CATKIN_IGNORE file to their source folder.
