### PR TITLE
Fixed the issue of some packages wrong repo version when catkin_build

### DIFF
--- a/gym_gazebo/envs/installation/gazebo.repos
+++ b/gym_gazebo/envs/installation/gazebo.repos
@@ -4,10 +4,10 @@ repositories:
 #    url: https://github.com/erlerobot/ardupilot_sitl_gazebo_plugin
 #
 #    version: master
-#  ar_track_alvar:
-#    type: git
-#    url: https://github.com/sniekum/ar_track_alvar
-#    version: indigo-devel
+  ar_track_alvar:
+    type: git
+    url: https://github.com/sniekum/ar_track_alvar
+    version: kinetic-devel
 #  ar_track_alvar_msgs:
 #    type: git
 #    url: https://github.com/sniekum/ar_track_alvar_msgs
@@ -27,19 +27,19 @@ repositories:
   ecl_core:
     type: git
     url: https://github.com/stonier/ecl_core
-    version: devel
+    version: release/0.61-indigo-kinetic
   ecl_lite:
     type: git
     url: https://github.com/stonier/ecl_lite
-    version: devel
+    version: release/0.61-indigo-kinetic
   ecl_navigation:
     type: git
     url: https://github.com/stonier/ecl_navigation
-    version: devel
+    version: release/0.60-indigo-kinetic
   ecl_tools:
     type: git
     url: https://github.com/stonier/ecl_tools
-    version: devel
+    version: release/0.61-indigo-kinetic
   driver_base:
     type: git
     url: https://github.com/ros-drivers/driver_common.git


### PR DESCRIPTION
Fixed the catkin_make error for pakcages include ecl_core, ecl_lite, ecl_navigation, ecl_tools and ar_track_alvar repo version wrong issue.