### PR TITLE
Fix liveplot in turtlebot examples

### DIFF
--- a/examples/erlecopter/erlecopter_hover_qlearn.py
+++ b/examples/erlecopter/erlecopter_hover_qlearn.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
     env = gym.make('GazeboErleCopterHover-v0')
 
     outdir = '/tmp/gazebo_gym_experiments'
-    env.monitor.start(outdir, force=True, seed=None)
+    env = gym.wrappers.Monitor(env, outdir, force=True)
     #plotter = LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
@@ -108,5 +108,4 @@ if __name__ == '__main__':
     print("Overall score: {:0.2f}".format(last_time_steps.mean()))
     print("Best 100 score: {:0.2f}".format(reduce(lambda x, y: x + y, l[-100:]) / len(l[-100:])))
 
-    env.monitor.close()
     env.close()

--- a/examples/erlerover/maze_erlerover_lidar_qlearn.py
+++ b/examples/erlerover/maze_erlerover_lidar_qlearn.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
     env = gym.make('GazeboMazeErleRoverLidar-v0')
 
     outdir = '/tmp/gazebo_gym_experiments'
-    env.monitor.start(outdir, force=True, seed=None)
+    env = gym.wrappers.Monitor(env, outdir, force=True)
     #plotter = LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
@@ -154,7 +154,7 @@ if __name__ == '__main__':
 
             qlearn.learn(state, action, reward, nextState)
 
-            env.monitor.flush(force=True)
+            env._flush(force=True)
 
             if not(done):
                 state = nextState
@@ -178,5 +178,4 @@ if __name__ == '__main__':
     print("Overall score: {:0.2f}".format(last_time_steps.mean()))
     print("Best 100 score: {:0.2f}".format(reduce(lambda x, y: x + y, l[-100:]) / len(l[-100:])))
 
-    env.monitor.close()
     env.close()

--- a/examples/gazebo_cartpole/gazebo_cartpole_v1.py
+++ b/examples/gazebo_cartpole/gazebo_cartpole_v1.py
@@ -147,7 +147,7 @@ env = gym.make('GazeboCartPole-v0')
 outdir = '/tmp/gazebo_gym_experiments'
 plotter = LivePlot(outdir)
 import time
-#env.monitor.start('cartpole-hill/', force=True)
+env = gym.wrappers.Monitor(env, outdir, force=True)
 policy_grad = policy_gradient()
 value_grad = value_gradient()
 sess = tf.InteractiveSession()
@@ -169,5 +169,4 @@ for _ in range(1000):
     reward = run_episode(env, policy_grad, value_grad, sess)
     t += reward
 print (t / 1000)
-#env.monitor.close()
 print ("END!")

--- a/examples/turtlebot/circuit2_turtlebot_lidar_dqn.py
+++ b/examples/turtlebot/circuit2_turtlebot_lidar_dqn.py
@@ -292,7 +292,6 @@ if __name__ == '__main__':
 
         deepQ = DeepQ(network_inputs, network_outputs, memorySize, discountFactor, learningRate, learnStart)
         deepQ.initNetworks(network_structure)
-        env.monitor.start(outdir, force=True, seed=None)
     else:
         #Load weights, monitor info and parameter info.
         #ADD TRY CATCH fro this else
@@ -318,7 +317,8 @@ if __name__ == '__main__':
 
         clear_monitor_files(outdir)
         copy_tree(monitor_path,outdir)
-        env.monitor.start(outdir, resume=True, seed=None)
+
+    env = gym.wrappers.Monitor(env, outdir,force=not continue_execution, resume=continue_execution)
 
     last100Scores = [0] * 100
     last100ScoresIndex = 0
@@ -361,7 +361,7 @@ if __name__ == '__main__':
                 print ("reached the end! :D")
                 done = True
 
-            env.monitor.flush(force=True)
+            env._flush(force=True)
             if done:
                 last100Scores[last100ScoresIndex] = t
                 last100ScoresIndex += 1
@@ -377,7 +377,7 @@ if __name__ == '__main__':
                     if (epoch)%100==0:
                         #save model weights and monitoring data every 100 epochs.
                         deepQ.saveModel('/tmp/turtle_c2_dqn_ep'+str(epoch)+'.h5')
-                        env.monitor.flush()
+                        env._flush()
                         copy_tree(outdir,'/tmp/turtle_c2_dqn_ep'+str(epoch))
                         #save simulation parameters.
                         parameter_keys = ['epochs','steps','updateTargetNetwork','explorationRate','minibatch_size','learnStart','learningRate','discountFactor','memorySize','network_inputs','network_outputs','network_structure','current_epoch']
@@ -396,5 +396,4 @@ if __name__ == '__main__':
         # explorationRate -= (2.0/epochs)
         explorationRate = max (0.05, explorationRate)
 
-    env.monitor.close()
     env.close()

--- a/examples/turtlebot/circuit2_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/circuit2_turtlebot_lidar_qlearn.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     env = gym.make('GazeboCircuit2TurtlebotLidar-v0')
 
     outdir = '/tmp/gazebo_gym_experiments'
-    # env.monitor.start(outdir, force=True, seed=None)
+    env = gym.wrappers.Monitor(env, outdir, force=True)
     #plotter = LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
@@ -71,7 +71,7 @@ if __name__ == '__main__':
 
             qlearn.learn(state, action, reward, nextState)
 
-            # env.monitor.flush(force=True)
+            env._flush(force=True)
 
             if not(done):
                 state = nextState
@@ -93,5 +93,4 @@ if __name__ == '__main__':
     print("Overall score: {:0.2f}".format(last_time_steps.mean()))
     print("Best 100 score: {:0.2f}".format(reduce(lambda x, y: x + y, l[-100:]) / len(l[-100:])))
 
-    # env.monitor.close()
     env.close()

--- a/examples/turtlebot/circuit2_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/circuit2_turtlebot_lidar_qlearn.py
@@ -5,10 +5,9 @@ import time
 import numpy
 import random
 import time
-import matplotlib
-import matplotlib.pyplot as plt
+
 import qlearn
-#import liveplot
+import liveplot
 
 def render():
     render_skip = 0 #Skip first X episodes.
@@ -26,7 +25,7 @@ if __name__ == '__main__':
 
     outdir = '/tmp/gazebo_gym_experiments'
     env = gym.wrappers.Monitor(env, outdir, force=True)
-    #plotter = LivePlot(outdir)
+    plotter = liveplot.LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
 
@@ -78,6 +77,9 @@ if __name__ == '__main__':
             else:
                 last_time_steps = numpy.append(last_time_steps, [int(i + 1)])
                 break
+
+        if x%100==0:
+            plotter.plot(env)
 
         m, s = divmod(int(time.time() - start_time), 60)
         h, m = divmod(m, 60)

--- a/examples/turtlebot/circuit2_turtlebot_lidar_sarsa.py
+++ b/examples/turtlebot/circuit2_turtlebot_lidar_sarsa.py
@@ -6,8 +6,7 @@ import numpy
 import random
 import time
 
-import matplotlib
-import matplotlib.pyplot as plt
+import liveplot
 import sarsa
 
 
@@ -17,7 +16,7 @@ if __name__ == '__main__':
 
     outdir = '/tmp/gazebo_gym_experiments'
     env = gym.wrappers.Monitor(env, outdir, force=True)
-    #plotter = LivePlot(outdir)
+    plotter = liveplot.LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
 
@@ -70,7 +69,10 @@ if __name__ == '__main__':
                 state = nextState
             else:
                 last_time_steps = numpy.append(last_time_steps, [int(i + 1)])
-                break 
+                break
+
+        if x%100==0:
+            plotter.plot(env)
 
         m, s = divmod(int(time.time() - start_time), 60)
         h, m = divmod(m, 60)

--- a/examples/turtlebot/circuit2_turtlebot_lidar_sarsa.py
+++ b/examples/turtlebot/circuit2_turtlebot_lidar_sarsa.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     env = gym.make('GazeboCircuit2TurtlebotLidar-v0')
 
     outdir = '/tmp/gazebo_gym_experiments'
-    env.monitor.start(outdir, force=True, seed=None)
+    env = gym.wrappers.Monitor(env, outdir, force=True)
     #plotter = LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
@@ -64,7 +64,7 @@ if __name__ == '__main__':
             #sarsa.learn(state, action, reward, nextState)
             sarsa.learn(state, action, reward, nextState, nextAction)
 
-            env.monitor.flush(force=True)
+            env._flush(force=True)
 
             if not(done):
                 state = nextState
@@ -86,5 +86,4 @@ if __name__ == '__main__':
     print("Overall score: {:0.2f}".format(last_time_steps.mean()))
     print("Best 100 score: {:0.2f}".format(reduce(lambda x, y: x + y, l[-100:]) / len(l[-100:])))
 
-    env.monitor.close()
     env.close()

--- a/examples/turtlebot/circuit2c_turtlebot_camera_dqn.py
+++ b/examples/turtlebot/circuit2c_turtlebot_camera_dqn.py
@@ -242,7 +242,7 @@ if __name__ == '__main__':
 
         deepQ = DeepQ(network_outputs, memorySize, discountFactor, learningRate, learnStart)
         deepQ.initNetworks()
-        env.monitor.start(outdir, force=True, seed=None)
+        env = gym.wrappers.Monitor(env, outdir, force=True)
     else:
         #Load weights, monitor info and parameter info.
         with open(params_json) as outfile:
@@ -267,7 +267,7 @@ if __name__ == '__main__':
 
         clear_monitor_files(outdir)
         copy_tree(monitor_path,outdir)
-        env.monitor.start(outdir, resume=True, seed=None)
+        env = gym.wrappers.Monitor(env, outdir, resume=True)
 
     last100Rewards = [0] * 100
     last100RewardsIndex = 0
@@ -304,7 +304,7 @@ if __name__ == '__main__':
                 print ("reached the end")
                 done = True
 
-            env.monitor.flush(force=True)
+            env._flush(force=True)
             cumulated_reward += reward
 
             if done:
@@ -323,7 +323,7 @@ if __name__ == '__main__':
                     if (epoch)%100==0: 
                         #save model weights and monitoring data every 100 epochs. 
                         deepQ.saveModel('/tmp/turtle_c2c_dqn_ep'+str(epoch)+'.h5')
-                        env.monitor.flush()
+                        env._flush()
                         copy_tree(outdir,'/tmp/turtle_c2c_dqn_ep'+str(epoch))
                         #save simulation parameters.
                         parameter_keys = ['explorationRate','minibatch_size','learnStart','learningRate','discountFactor','memorySize','network_outputs','current_epoch','stepCounter','EXPLORE','INITIAL_EPSILON','FINAL_EPSILON','loadsim_seconds']
@@ -337,5 +337,4 @@ if __name__ == '__main__':
             if stepCounter % 2500 == 0:
                 print("Frames = "+str(stepCounter))
 
-    env.monitor.close() #not needed in latest gym update
     env.close()

--- a/examples/turtlebot/circuit_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/circuit_turtlebot_lidar_qlearn.py
@@ -6,8 +6,7 @@ import numpy
 import random
 import time
 
-import matplotlib
-import matplotlib.pyplot as plt
+import liveplot
 
 class QLearn:
     def __init__(self, actions, epsilon, alpha, gamma):
@@ -59,40 +58,6 @@ class QLearn:
         maxqnew = max([self.getQ(state2, a) for a in self.actions])
         self.learnQ(state1, action1, reward, reward + self.gamma*maxqnew)
 
-class LivePlot(object):
-    def __init__(self, outdir, data_key='episode_rewards', line_color='blue'):
-        """
-        Liveplot renders a graph of either episode_rewards or episode_lengths
-        Args:
-            outdir (outdir): Monitor output file location used to populate the graph
-            data_key (Optional[str]): The key in the json to graph (episode_rewards or episode_lengths).
-            line_color (Optional[dict]): Color of the plot.
-        """
-        self.outdir = outdir
-        self._last_data = None
-        self.data_key = data_key
-        self.line_color = line_color
-
-        #styling options
-        matplotlib.rcParams['toolbar'] = 'None'
-        plt.style.use('ggplot')
-        plt.xlabel("")
-        plt.ylabel(data_key)
-        fig = plt.gcf().canvas.set_window_title('simulation_graph')
-
-    def plot(self):
-        results = gym.monitoring.monitor.load_results(self.outdir)
-        data =  results[self.data_key]
-
-        #only update plot if data is different (plot calls are expensive)
-        if data !=  self._last_data:
-            self._last_data = data
-            plt.plot(data, color=self.line_color)
-
-            # pause so matplotlib will display
-            # may want to figure out matplotlib animation or use a different library in the future
-            plt.pause(0.000001)
-
 def render():
     render_skip = 0 #Skip first X episodes.
     render_interval = 50 #Show render Every Y episodes.
@@ -111,7 +76,7 @@ if __name__ == '__main__':
     outdir = '/tmp/gazebo_gym_experiments'
     env = gym.wrappers.Monitor(env, outdir, force=True)
 
-    #plotter = LivePlot(outdir)
+    #plotter = liveplot.LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
 

--- a/examples/turtlebot/circuit_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/circuit_turtlebot_lidar_qlearn.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     outdir = '/tmp/gazebo_gym_experiments'
     env = gym.wrappers.Monitor(env, outdir, force=True)
 
-    #plotter = liveplot.LivePlot(outdir)
+    plotter = liveplot.LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
 
@@ -128,6 +128,9 @@ if __name__ == '__main__':
             else:
                 last_time_steps = numpy.append(last_time_steps, [int(i + 1)])
                 break
+
+        if x % 100 == 0:
+            plotter.plot(env)
 
         m, s = divmod(int(time.time() - start_time), 60)
         h, m = divmod(m, 60)

--- a/examples/turtlebot/circuit_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/circuit_turtlebot_lidar_qlearn.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
 
 
     outdir = '/tmp/gazebo_gym_experiments'
-    # env.monitor.start(outdir, force=True, seed=None)
+    env = gym.wrappers.Monitor(env, outdir, force=True)
 
     #plotter = LivePlot(outdir)
 
@@ -156,7 +156,7 @@ if __name__ == '__main__':
 
             qlearn.learn(state, action, reward, nextState)
 
-            # env.monitor.flush(force=True)
+            env._flush(force=True)
 
             if not(done):
                 state = nextState
@@ -178,5 +178,4 @@ if __name__ == '__main__':
     print("Overall score: {:0.2f}".format(last_time_steps.mean()))
     print("Best 100 score: {:0.2f}".format(reduce(lambda x, y: x + y, l[-100:]) / len(l[-100:])))
 
-    #env.monitor.close()
     env.close()

--- a/examples/turtlebot/liveplot.py
+++ b/examples/turtlebot/liveplot.py
@@ -19,7 +19,7 @@ class LivePlot(object):
         #styling options
         matplotlib.rcParams['toolbar'] = 'None'
         plt.style.use('ggplot')
-        plt.xlabel("")
+        plt.xlabel("Episodes")
         plt.ylabel(data_key)
         fig = plt.gcf().canvas.set_window_title('simulation_graph')
 

--- a/examples/turtlebot/liveplot.py
+++ b/examples/turtlebot/liveplot.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 import matplotlib
 import matplotlib.pyplot as plt
+import gym
+
+rewards_key = 'episode_rewards'
 
 class LivePlot(object):
-    def __init__(self, outdir, data_key='episode_rewards', line_color='blue'):
+    def __init__(self, outdir, data_key=rewards_key, line_color='blue'):
         """
         Liveplot renders a graph of either episode_rewards or episode_lengths
         Args:
@@ -12,7 +15,6 @@ class LivePlot(object):
             line_color (Optional[dict]): Color of the plot.
         """
         self.outdir = outdir
-        self._last_data = None
         self.data_key = data_key
         self.line_color = line_color
 
@@ -23,15 +25,14 @@ class LivePlot(object):
         plt.ylabel(data_key)
         fig = plt.gcf().canvas.set_window_title('simulation_graph')
 
-    def plot(self):
-        results = gym.monitoring.monitor.load_results(self.outdir)
-        data =  results[self.data_key]
+    def plot(self, env):
+        if self.data_key is rewards_key:
+            data = gym.wrappers.Monitor.get_episode_rewards(env)
+        else:
+            data = gym.wrappers.Monitor.get_episode_lengths(env)
 
-        #only update plot if data is different (plot calls are expensive)
-        if data !=  self._last_data:
-            self._last_data = data
-            plt.plot(data, color=self.line_color)
+        plt.plot(data, color=self.line_color)
 
-            # pause so matplotlib will display
-            # may want to figure out matplotlib animation or use a different library in the future
-            plt.pause(0.000001)
+        # pause so matplotlib will display
+        # may want to figure out matplotlib animation or use a different library in the future
+        plt.pause(0.000001)

--- a/examples/turtlebot/maze_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/maze_turtlebot_lidar_qlearn.py
@@ -5,9 +5,7 @@ import time
 import numpy
 import random
 import time
-
-import matplotlib
-import matplotlib.pyplot as plt
+import liveplot
 
 class QLearn:
     def __init__(self, actions, epsilon, alpha, gamma):
@@ -75,7 +73,7 @@ if __name__ == '__main__':
 
     outdir = '/tmp/gazebo_gym_experiments'
     env = gym.wrappers.Monitor(env, outdir, force=True)
-    #plotter = LivePlot(outdir)
+    plotter = liveplot.LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
 
@@ -128,8 +126,8 @@ if __name__ == '__main__':
                 last_time_steps = numpy.append(last_time_steps, [int(i + 1)])
                 break 
 
-        #if x%100==0:
-        #    plotter.plot()
+        if x%100==0:
+            plotter.plot(env)
 
         m, s = divmod(int(time.time() - start_time), 60)
         h, m = divmod(m, 60)

--- a/examples/turtlebot/maze_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/maze_turtlebot_lidar_qlearn.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
     env = gym.make('GazeboMazeTurtlebotLidar-v0')
 
     outdir = '/tmp/gazebo_gym_experiments'
-    env.monitor.start(outdir, force=True, seed=None)
+    env = gym.wrappers.Monitor(env, outdir, force=True)
     #plotter = LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
@@ -154,7 +154,7 @@ if __name__ == '__main__':
 
             qlearn.learn(state, action, reward, nextState)
 
-            env.monitor.flush(force=True)
+            env._flush(force=True)
             
             if not(done):
                 state = nextState
@@ -179,5 +179,4 @@ if __name__ == '__main__':
     print("Overall score: {:0.2f}".format(last_time_steps.mean()))
     print("Best 100 score: {:0.2f}".format(reduce(lambda x, y: x + y, l[-100:]) / len(l[-100:])))
 
-    env.monitor.close()
     env.close()

--- a/examples/turtlebot/maze_turtlebot_lidar_qlearn.py
+++ b/examples/turtlebot/maze_turtlebot_lidar_qlearn.py
@@ -59,40 +59,6 @@ class QLearn:
         maxqnew = max([self.getQ(state2, a) for a in self.actions])
         self.learnQ(state1, action1, reward, reward + self.gamma*maxqnew)
 
-class LivePlot(object):
-    def __init__(self, outdir, data_key='episode_rewards', line_color='blue'):
-        """
-        Liveplot renders a graph of either episode_rewards or episode_lengths
-        Args:
-            outdir (outdir): Monitor output file location used to populate the graph
-            data_key (Optional[str]): The key in the json to graph (episode_rewards or episode_lengths).
-            line_color (Optional[dict]): Color of the plot.
-        """
-        self.outdir = outdir
-        self._last_data = None
-        self.data_key = data_key
-        self.line_color = line_color
-
-        #styling options
-        matplotlib.rcParams['toolbar'] = 'None'
-        plt.style.use('ggplot')
-        plt.xlabel("Episodes")
-        plt.ylabel(data_key)
-        fig = plt.gcf().canvas.set_window_title('simulation_graph')
-
-    def plot(self):
-        results = gym.monitoring.monitor.load_results(self.outdir)
-        data =  results[self.data_key]
-
-        #only update plot if data is different (plot calls are expensive)
-        if data !=  self._last_data:
-            self._last_data = data
-            plt.plot(data, color=self.line_color)
-
-            # pause so matplotlib will display
-            # may want to figure out matplotlib animation or use a different library in the future
-            plt.pause(0.000001)
-
 def render():
     render_skip = 0 #Skip first X episodes.
     render_interval = 50 #Show render Every Y episodes.

--- a/examples/turtlebot/round_turtlebot_lidar_test.py
+++ b/examples/turtlebot/round_turtlebot_lidar_test.py
@@ -6,8 +6,7 @@ import numpy
 import random
 import time
 
-import matplotlib
-import matplotlib.pyplot as plt
+import liveplot
 
 class QLearn:
     def __init__(self, actions, epsilon, alpha, gamma):
@@ -59,40 +58,6 @@ class QLearn:
         maxqnew = max([self.getQ(state2, a) for a in self.actions])
         self.learnQ(state1, action1, reward, reward + self.gamma*maxqnew)
 
-class LivePlot(object):
-    def __init__(self, outdir, data_key='episode_rewards', line_color='blue'):
-        """
-        Liveplot renders a graph of either episode_rewards or episode_lengths
-        Args:
-            outdir (outdir): Monitor output file location used to populate the graph
-            data_key (Optional[str]): The key in the json to graph (episode_rewards or episode_lengths).
-            line_color (Optional[dict]): Color of the plot.
-        """
-        self.outdir = outdir
-        self._last_data = None
-        self.data_key = data_key
-        self.line_color = line_color
-
-        #styling options
-        matplotlib.rcParams['toolbar'] = 'None'
-        plt.style.use('ggplot')
-        plt.xlabel("")
-        plt.ylabel(data_key)
-        fig = plt.gcf().canvas.set_window_title('simulation_graph')
-
-    def plot(self):
-        results = gym.monitoring.monitor.load_results(self.outdir)
-        data =  results[self.data_key]
-
-        #only update plot if data is different (plot calls are expensive)
-        if data !=  self._last_data:
-            self._last_data = data
-            plt.plot(data, color=self.line_color)
-
-            # pause so matplotlib will display
-            # may want to figure out matplotlib animation or use a different library in the future
-            plt.pause(0.000001)
-
 def render():
     render_skip = 0 #Skip first X episodes.
     render_interval = 50 #Show render Every Y episodes.
@@ -109,7 +74,7 @@ if __name__ == '__main__':
 
     outdir = '/tmp/gazebo_gym_experiments'
     env = gym.wrappers.Monitor(env, outdir, force=True)
-    #plotter = LivePlot(outdir)
+    plotter = liveplot.LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
 
@@ -162,8 +127,8 @@ if __name__ == '__main__':
                 last_time_steps = numpy.append(last_time_steps, [int(i + 1)])
                 break 
 
-        #if x%100==0:
-        #    plotter.plot()
+        if x%100==0:
+            plotter.plot(env)
 
         m, s = divmod(int(time.time() - start_time), 60)
         h, m = divmod(m, 60)

--- a/examples/turtlebot/round_turtlebot_lidar_test.py
+++ b/examples/turtlebot/round_turtlebot_lidar_test.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
     env = gym.make('GazeboRoundTurtlebotLidar-v0')
 
     outdir = '/tmp/gazebo_gym_experiments'
-    env.monitor.start(outdir, force=True, seed=None)
+    env = gym.wrappers.Monitor(env, outdir, force=True)
     #plotter = LivePlot(outdir)
 
     last_time_steps = numpy.ndarray(0)
@@ -154,7 +154,7 @@ if __name__ == '__main__':
 
             qlearn.learn(state, action, reward, nextState)
 
-            env.monitor.flush(force=True)
+            env._flush(force=True)
             
             if not(done):
                 state = nextState
@@ -179,5 +179,4 @@ if __name__ == '__main__':
     print("Overall score: {:0.2f}".format(last_time_steps.mean()))
     print("Best 100 score: {:0.2f}".format(reduce(lambda x, y: x + y, l[-100:]) / len(l[-100:])))
 
-    env.monitor.close()
     env.close()


### PR DESCRIPTION
* Fixes liveplot.py to correctly plot without error. 
--> plot() function now requires the env parameter:  plot(env)
* Refactors class LivePlot out of turtlebot examples
* Enables plotting every 100 cycles in examples

Currently based on top of monitor bug fix (#130), should be rebased to master once that is merged. 

Note - more work is needed to fix the other examples (cartpole, erlerover, etc.)