### PR TITLE
added max_episode_steps to registration for DQN

### DIFF
--- a/gym_gazebo/__init__.py
+++ b/gym_gazebo/__init__.py
@@ -25,6 +25,7 @@ register(
 register(
     id='GazeboCircuit2TurtlebotLidarNn-v0',
     entry_point='gym_gazebo.envs.turtlebot:GazeboCircuit2TurtlebotLidarNnEnv',
+    max_episode_steps=1000,
     # More arguments here
 )
 register(


### PR DESCRIPTION
For issue #135, the fix I made in my prior PR #140 was incomplete. The max_episode_steps must be set at registration time in order for it to be available to set in the env as env._max_episode_steps. So my prior fix by itself won't work. This sets it to 1000 by default, but allows the code in the example to override it to something else. ex: env._max_episode_steps = 500